### PR TITLE
Dev fix pypi missing data python requires (WIP)

### DIFF
--- a/plugins/nexus-repository-pypi/src/main/java/org/sonatype/nexus/repository/pypi/internal/PyPiIndexUtils.java
+++ b/plugins/nexus-repository-pypi/src/main/java/org/sonatype/nexus/repository/pypi/internal/PyPiIndexUtils.java
@@ -19,10 +19,9 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Map.Entry;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -52,11 +51,20 @@ public final class PyPiIndexUtils
   private static final Logger log = LoggerFactory.getLogger(PyPiIndexUtils.class);
 
   /**
-   * Returns a map (in original order of appearance) of the files and associated paths extracted from the index.
+   * From PEP_053:
+   * A repository MAY include a data-requires-python attribute on a file link.
+   * This exposes the Requires-Python metadata field, specified in PEP 345, for the corresponding release.
+   * Where this is present, installer tools SHOULD ignore the download when installing
+   * to a Python version that doesn't satisfy the requirement.
    */
-  static Map<String, String> extractLinksFromIndex(final InputStream in) throws IOException {
+  private static final String PYPI_REQUIRES_PYTHON = "data-requires-python";
+
+  /**
+   * Return a list (in original order of appearance) of PyPiLinkInfo extracted from the index.
+   */
+  static List<PyPiLink> extractLinksFromIndex(final InputStream in) throws IOException {
     checkNotNull(in);
-    Map<String, String> results = new LinkedHashMap<>();
+    List<PyPiLink> results = new LinkedList<>();
     try (Reader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
       String html = CharStreams.toString(reader);
       Document document = Jsoup.parse(html);
@@ -64,47 +72,59 @@ public final class PyPiIndexUtils
       for (Element link : links) {
         String file = link.text().trim();
         String path = link.attr("href");
-        if (!results.containsKey(file)) {
-          results.put(file, path);
-        }
+        String requiresPython = link.attr(PYPI_REQUIRES_PYTHON);
+        results.add(new PyPiLink(file, path, requiresPython));
       }
     }
     return results;
   }
 
+
+  /**
+   * Convert a link to a map ready to be used for "pypi-index.vm".
+   */
+  static ImmutableMap<String, String> indexLinkToMap(PyPiLink link) {
+    return ImmutableMap.of(
+            "link", makePackageLinkRelative(link.getLink()),
+            "file", link.getFile(),
+            "data-requires-python", link.getDataPythonRequires()
+    );
+  }
+
+  /**
+   * Convert a link to a map ready to be used for "pypi-root-index.vm".
+   */
+  static ImmutableMap<String, String> rootIndexLinkToMap(PyPiLink link) {
+    return ImmutableMap.of(
+            "link", makeRootIndexLinkRelative(link.getLink()),
+            "name", link.getFile()
+    );
+  }
+
   /**
    * Returns a string containing the HTML simple index page for the links, rendered in iteration order.
    */
-  static String buildIndexPage(final TemplateHelper helper, final String name, final Map<String, String> links) {
+  static String buildIndexPage(final TemplateHelper helper, final String name, final Collection<PyPiLink> links) {
     checkNotNull(helper);
     checkNotNull(name);
     checkNotNull(links);
     URL template = PyPiIndexUtils.class.getResource("pypi-index.vm");
     TemplateParameters params = helper.parameters();
     params.set("name", name);
-    params.set("assets", links.entrySet().stream()
-        .map((link) -> ImmutableMap.of(
-            "link", link.getValue(),
-            "file", link.getKey())
-        )
-        .collect(Collectors.toList()));
+    params.set("assets", links.stream().map(PyPiIndexUtils::indexLinkToMap).collect(Collectors.toList()));
     return helper.render(template, params);
   }
+
 
   /**
    * Returns a string containing the HTML simple root index page for the links, rendered in iteration order.
    */
-  static String buildRootIndexPage(final TemplateHelper helper, final Map<String, String> links) {
+  static String buildRootIndexPage(final TemplateHelper helper, final Collection<PyPiLink> links) {
     checkNotNull(helper);
     checkNotNull(links);
     URL template = PyPiIndexUtils.class.getResource("pypi-root-index.vm");
     TemplateParameters params = helper.parameters();
-    params.set("assets", links.entrySet().stream().map((link) -> {
-      Map<String, String> data = new HashMap<>();
-      data.put("link", link.getValue());
-      data.put("name", link.getKey());
-      return data;
-    }).collect(Collectors.toList()));
+    params.set("assets", links.stream().map(PyPiIndexUtils::rootIndexLinkToMap).collect(Collectors.toList()));
     return helper.render(template, params);
   }
 
@@ -113,45 +133,27 @@ public final class PyPiIndexUtils
    * assumption based on email discussions with donald@stufft.io that there are no plans to have packages at any
    * location other than under the /packages directory.
    */
-  private static Map<String, String> makeLinksRelative(final Map<String, String> oldLinks,
-                                                       final Function<String, String> linkTranslator) {
-    checkNotNull(oldLinks);
-    Map<String, String> newLinks = new LinkedHashMap<>();
-    for (Entry<String, String> oldLink : oldLinks.entrySet()) {
-      String newLink = linkTranslator.apply(oldLink.getValue());
-      if (newLink != null) {
-        newLinks.put(oldLink.getKey(), newLink);
-      }
+  private static String makeLinkRelative(final String oldLink, final Function<String, String> linkTranslator) {
+    checkNotNull(oldLink);
+    String newLink = linkTranslator.apply(oldLink);
+    if (newLink != null) {
+      return newLink;
     }
-    return newLinks;
+    return oldLink;
   }
 
   /**
    * Rewrites an index page so that the links are all relative where possible.
    */
-  static Map<String, String> makeIndexRelative(final InputStream in) throws IOException {
-    return makePackageLinksRelative(extractLinksFromIndex(in));
-  }
-
-  /**
-   * Rewrites an index page so that the links are all relative where possible.
-   */
-  static Map<String, String> makePackageLinksRelative(final Map<String, String> oldLinks) {
-    return makeLinksRelative(oldLinks, PyPiIndexUtils::maybeRewriteLink);
+  private static String makePackageLinkRelative(final String oldLink) {
+    return makeLinkRelative(oldLink, PyPiIndexUtils::maybeRewriteLink);
   }
 
   /**
    * Rewrites a root index page from a stream so that the links are all relative where possible.
    */
-  static Map<String, String> makeRootIndexRelative(final InputStream in) throws IOException {
-    return makeRootIndexLinksRelative(extractLinksFromIndex(in));
-  }
-
-  /**
-   * Rewrites a root index page so that the links are all relative where possible.
-   */
-  static Map<String, String> makeRootIndexLinksRelative(final Map<String, String> oldLinks) {
-    return makeLinksRelative(oldLinks, PyPiIndexUtils::maybeRewriteRootLink);
+  private static String makeRootIndexLinkRelative(final String oldLink) {
+    return makeLinkRelative(oldLink, PyPiIndexUtils::maybeRewriteRootLink);
   }
 
   /**

--- a/plugins/nexus-repository-pypi/src/main/java/org/sonatype/nexus/repository/pypi/internal/PyPiLink.java
+++ b/plugins/nexus-repository-pypi/src/main/java/org/sonatype/nexus/repository/pypi/internal/PyPiLink.java
@@ -1,0 +1,38 @@
+package org.sonatype.nexus.repository.pypi.internal;
+
+import javax.annotation.Nonnull;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Container for URL PEP 503 compatible urls.
+ */
+final class PyPiLink {
+    private final String file;
+
+    private final String link;
+
+    private final String dataPythonRequires;
+
+    PyPiLink(@Nonnull final String file, @Nonnull final String link, @Nonnull final String dataPythonRequires) {
+        this.file = checkNotNull(file);
+        this.link = checkNotNull(link);
+        this.dataPythonRequires = dataPythonRequires;
+    }
+
+    PyPiLink(@Nonnull final String file, @Nonnull final String link) {
+        this(file, link, "");
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public String getFile() {
+        return file;
+    }
+
+    public String getDataPythonRequires() {
+        return dataPythonRequires;
+    }
+}

--- a/plugins/nexus-repository-pypi/src/main/java/org/sonatype/nexus/repository/pypi/internal/PyPiProxyFacetImpl.java
+++ b/plugins/nexus-repository-pypi/src/main/java/org/sonatype/nexus/repository/pypi/internal/PyPiProxyFacetImpl.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -70,8 +71,7 @@ import static org.sonatype.nexus.repository.pypi.internal.PyPiFileUtils.extractN
 import static org.sonatype.nexus.repository.pypi.internal.PyPiFileUtils.extractVersionFromFilename;
 import static org.sonatype.nexus.repository.pypi.internal.PyPiIndexUtils.buildIndexPage;
 import static org.sonatype.nexus.repository.pypi.internal.PyPiIndexUtils.buildRootIndexPage;
-import static org.sonatype.nexus.repository.pypi.internal.PyPiIndexUtils.makeIndexRelative;
-import static org.sonatype.nexus.repository.pypi.internal.PyPiIndexUtils.makeRootIndexRelative;
+import static org.sonatype.nexus.repository.pypi.internal.PyPiIndexUtils.extractLinksFromIndex;
 import static org.sonatype.nexus.repository.pypi.internal.PyPiInfoUtils.extractMetadata;
 import static org.sonatype.nexus.repository.pypi.internal.PyPiPathUtils.INDEX_PATH_PREFIX;
 import static org.sonatype.nexus.repository.pypi.internal.PyPiPathUtils.indexPath;
@@ -242,16 +242,17 @@ public class PyPiProxyFacetImpl
 
   private Content putRootIndex(final Content content) throws IOException {
     try (InputStream inputStream = content.openInputStream()) {
-      Map<String, String> links = makeRootIndexRelative(inputStream);
+      List<PyPiLink> links = extractLinksFromIndex(inputStream);
       String indexPage = buildRootIndexPage(templateHelper, links);
       return storeHtmlPage(content, indexPage, ROOT_INDEX, INDEX_PATH_PREFIX);
     }
   }
 
+
   private Content putIndex(final String name, final Content content) throws IOException {
     String html;
     try (InputStream inputStream = content.openInputStream()) {
-      Map<String, String> links = makeIndexRelative(inputStream);
+      List<PyPiLink> links = extractLinksFromIndex(inputStream);
       html = buildIndexPage(templateHelper, name.substring(name.indexOf('/') + 1, name.length() - 1), links);
     }
     return storeHtmlPage(content, html, INDEX, name);

--- a/plugins/nexus-repository-pypi/src/main/resources/org/sonatype/nexus/repository/pypi/internal/pypi-index.vm
+++ b/plugins/nexus-repository-pypi/src/main/resources/org/sonatype/nexus/repository/pypi/internal/pypi-index.vm
@@ -16,7 +16,8 @@
 </head>
 <body><h1>Links for ${name}</h1>
   #foreach($asset in $assets)
-  <a href="${asset.get('link')}" rel="internal">${asset.get('file')}</a><br/>
+  #set($dataRequiresPython = ${asset.get('data-requires-python')})
+  <a href="${asset.get('link')}" rel="internal"#if( "$dataRequiresPython" != "" ) data-requires-python="${dataRequiresPython}"#end>${asset.get('file')}</a><br/>
   #end
 </body>
 </html>

--- a/plugins/nexus-repository-pypi/src/test/java/org/sonatype/nexus/repository/pypi/internal/PyPiHostedFacetImplTest.java
+++ b/plugins/nexus-repository-pypi/src/test/java/org/sonatype/nexus/repository/pypi/internal/PyPiHostedFacetImplTest.java
@@ -14,7 +14,6 @@ package org.sonatype.nexus.repository.pypi.internal;
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Set;
 
 import org.sonatype.goodies.testsupport.TestSupport;
 import org.sonatype.nexus.common.template.TemplateHelper;
@@ -79,10 +78,8 @@ public class PyPiHostedFacetImplTest
     ));
     underTest.attach(repository);
 
-    Map<String, String> links = underTest.findAllLinks();
-
-    Set<String> strings = links.keySet();
-    String[] result = strings.toArray(new String[0]);
+    Map<String, PyPiLink> links = underTest.findAllLinks();
+    String[] result = links.values().stream().map(PyPiLink::getFile).distinct().toArray(String[]::new);
     assertThat(result[0], is("0"));
     assertThat(result[1], is("a"));
     assertThat(result[2], is("z"));

--- a/plugins/nexus-repository-pypi/src/test/resources/org/sonatype/nexus/repository/pypi/internal/sample-index-invalid.html
+++ b/plugins/nexus-repository-pypi/src/test/resources/org/sonatype/nexus/repository/pypi/internal/sample-index-invalid.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+    <title>Links for sample</title>
+    <meta name="api-version" value="2"/>
+</head>
+<body>
+<h1>Links for sample</h1>
+<a href="../../packages/sample-1.2.0.tar.bz2#md5=00c3db1c8ab5d10a2049fe384c8d53e5">sample-1.2.0.tar.bz2</a><br/>
+<a href="/packages/sample-1.2.1-py2.py3-none-any.whl#md5=5c286195d47014fa0ba6e4e5b0801faf">sample-1.2.1-py2.py3-none-any.whl</a><br/>
+<a href="http://example.com/packages/sample-1.2.1-py2.py3-none-any.whl#md5=5c286195d47014fa0ba6e4e5b0801faf">sample-1.2.2-py2.py3-none-any.whl<br/>
+<a href="http://example.com/test">test</a><br/>
+</body>
+</html>

--- a/plugins/nexus-repository-pypi/src/test/resources/org/sonatype/nexus/repository/pypi/internal/sample-index.html
+++ b/plugins/nexus-repository-pypi/src/test/resources/org/sonatype/nexus/repository/pypi/internal/sample-index.html
@@ -7,6 +7,6 @@
 <h1>Links for sample</h1>
 <a href="/packages/sample-1.2.0.tar.bz2#md5=00c3db1c8ab5d10a2049fe384c8d53e5">sample-1.2.0.tar.bz2</a><br>
 <a href="/packages/sample-1.2.1-py2.py3-none-any.whl#md5=5c286195d47014fa0ba6e4e5b0801faf">sample-1.2.1-py2.py3-none-any.whl</a><br>
-<a href="/packages/sample-1.2.1.tar.gz#md5=8c59858420df240b68e259ceae78a11d">sample-1.2.1.tar.gz</a><br>
+<a href="/packages/sample-1.2.1.tar.gz#md5=8c59858420df240b68e259ceae78a11d" data-requires-python=">=3.7">sample-1.2.1.tar.gz</a><br>
 </body>
 </html>


### PR DESCRIPTION
Note: This PR is here so I can gatter review from peers. It's WIP and I'll do a real PR to sonatype once I feel ready.

---

Description:

There's currently an issue where nexus-repository-pypi don't provide the "data-python-requires" when building the index.

Here's the link for pytest-5.1.1 on our nexus instance:
![image](https://user-images.githubusercontent.com/43388715/65692586-cfc78900-e040-11e9-839f-2c4cd718b66c.png)

Here's the link for pytest-5.1.1 on pypi (https://pypi.org/simple/pytest/):
![image](https://user-images.githubusercontent.com/43388715/65692726-14ebbb00-e041-11e9-8f2f-d13a6d37da4f.png)

Here's the link for pytest-5.1.1 on my local nexus instance after the changes:
![image](https://user-images.githubusercontent.com/43388715/65696857-fa691000-e047-11e9-9813-57ba87498cd0.png)

This missing attribute prevent pip from knowing if a package is compatible with the current python interpreter. In our cases, packages not compatible with python-2.7 where installed in a python-2.7 environment.

This PR ensure that the "data-requires-python" is provided when building a "pypi-proxy", "pypi-hosted" and "pypi-all" index.

---

About the changes:

The function `extractLinksFromIndex` was returning a `Map<String, String>` where the key was the link name and the value was the link destination. To address the issue I had to store more information (the "data-requires-python" attribute). In my first prototype I changed the function to return a `Map<String, Map<String, String>>`, however it was not very clear. I then decided to add a "container" class `PyPiLinkInfo` which contained everything I needed so now I simply return a `List<PyPiLinkInfo>`.

What I would like to improve
* Is there a datatype that I can use instead of `PyPiLinkInfo`?
* I don't like the tests, I would love to refactor them so I can render a page for each repository type.